### PR TITLE
Fix HTTPS detection for ROOT_ABSOLUTE_URL_PATH

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -85,7 +85,7 @@ if (!function_exists('PHPBootstrap\bootstrap')) {
 		*/
 		$https = false;
 		$default_port = 80;
-		if (array_key_exists('HTTPS', $_SERVER)) {
+		if (array_key_exists('HTTPS', $_SERVER) and $_SERVER['HTTPS'] and $_SERVER['HTTPS'] != 'off') {
 			$https = true;
 			$default_port = 443;
 		}


### PR DESCRIPTION
HTTPS will be defined but empty in most HTTP cases: http://www.php.net/manual/en/reserved.variables.server.php
